### PR TITLE
Make rc-yaml compatible with node 4.x and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 0.12
   - 4
   - 6
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - 4
   - 6
 sudo: false

--- a/lib/rc-yaml.js
+++ b/lib/rc-yaml.js
@@ -10,7 +10,7 @@ function parser (content, file) {
     return JSON.parse(stripJsonComments(content));
   }
 
-  const config = yaml.load(content);
+  var config = yaml.load(content);
 
   if (typeof config === 'object') {
     return config;

--- a/lib/rc-yaml.js
+++ b/lib/rc-yaml.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var yaml = require('yaml-js');
+var yaml = require('js-yaml');
 var rc = require('rc');
 var ini = require('ini');
 var stripJsonComments = require('strip-json-comments');

--- a/lib/rc-yaml.js
+++ b/lib/rc-yaml.js
@@ -19,8 +19,8 @@ function parser (content, file) {
   return ini.parse(content);
 }
 
-function rcYaml (name, defaults, argv, parse = parser) {
-  return rc(name, defaults, argv, parse);
+function rcYaml (name, defaults, argv, parse) {
+  return rc(name, defaults, argv, parse || parser);
 }
 
 rcYaml.parser = parser;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rc-yaml",
+  "name": "rc-yaml-2",
   "version": "1.0.0",
   "description": "Extend the RC module with YAML parsing",
   "main": "lib/rc-yaml.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/boneskull/rc-yaml.git"
+    "url": "git+https://github.com/megastef/rc-yaml.git"
   },
   "keywords": [
     "rc",
@@ -20,12 +20,12 @@
   "author": "Christopher Hiller <boneskull@boneskull.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/boneskull/rc-yaml/issues"
+    "url": "https://github.com/megastef/rc-yaml/issues"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=0.12"
   },
-  "homepage": "https://github.com/boneskull/rc-yaml#readme",
+  "homepage": "https://github.com/megastef/rc-yaml#readme",
   "dependencies": {
     "ini": "^1.3.4",
     "rc": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-yaml-2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Extend the RC module with YAML parsing",
   "main": "lib/rc-yaml.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "homepage": "https://github.com/megastef/rc-yaml#readme",
   "dependencies": {
     "ini": "^1.3.4",
+    "js-yaml": "^3.8.1",
     "rc": "^1.0.3",
-    "strip-json-comments": "^2.0.1",
-    "yaml-js": "^0.1.1"
+    "strip-json-comments": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-yaml-2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Extend the RC module with YAML parsing",
   "main": "lib/rc-yaml.js",
   "scripts": {


### PR DESCRIPTION
We use rc-yaml for the configuration of spm-agent-nodejs to monitor Node applications. We like to support users running node 0.12 and node 4. 